### PR TITLE
Fix incorrect patch offset of the 0005 patch

### DIFF
--- a/patches/u-boot/0005-board-sifive-spl-Set-remote-thermal-of-TMP451-to-85-.patch
+++ b/patches/u-boot/0005-board-sifive-spl-Set-remote-thermal-of-TMP451-to-85-.patch
@@ -91,10 +91,10 @@ index 7029bb7b5c..a39c665d02 100644
  	hex "EEPROM Address Overflow"
  	default 0x0
 diff --git a/include/configs/sifive-unmatched.h b/include/configs/sifive-unmatched.h
-index 1fd198e8df..22f347a579 100644
+index 9923f3d9c3..96c6e8df66 100644
 --- a/include/configs/sifive-unmatched.h
 +++ b/include/configs/sifive-unmatched.h
-@@ -32,6 +32,10 @@
+@@ -15,6 +15,10 @@
  
  #define CONFIG_STANDALONE_LOAD_ADDR	0x80200000
  
@@ -104,19 +104,16 @@ index 1fd198e8df..22f347a579 100644
 +
  /* Environment options */
  
- #ifndef CONFIG_SPL_BUILD
+ #define BOOT_TARGET_DEVICES(func) \
 diff --git a/scripts/config_whitelist.txt b/scripts/config_whitelist.txt
-index a6bc234f51..b438e06a16 100644
+index 53328e11d6..e432ce0e5f 100644
 --- a/scripts/config_whitelist.txt
 +++ b/scripts/config_whitelist.txt
-@@ -1954,6 +1954,7 @@ CONFIG_SYS_TIMER_BASE
+@@ -1288,6 +1288,7 @@ CONFIG_SYS_TIMER_BASE
  CONFIG_SYS_TIMER_COUNTER
  CONFIG_SYS_TIMER_COUNTS_DOWN
  CONFIG_SYS_TIMER_RATE
 +CONFIG_SYS_TMP451_BUS_NUM
  CONFIG_SYS_TMPVIRT
  CONFIG_SYS_TSEC1_OFFSET
- CONFIG_SYS_TSEC2_OFFSET
--- 
-2.28.0
-
+ CONFIG_SYS_TX_ETH_BUFFER

--- a/patches/u-boot/0007-riscv-sifive-unmatched-disable-FDT-and-initrd-reloca.patch
+++ b/patches/u-boot/0007-riscv-sifive-unmatched-disable-FDT-and-initrd-reloca.patch
@@ -18,18 +18,18 @@ Signed-off-by: David Abdurachmanov <david.abdurachmanov@sifive.com>
  1 file changed, 2 insertions(+)
 
 diff --git a/include/configs/sifive-unmatched.h b/include/configs/sifive-unmatched.h
-index 4984e2cfcb..61ac6b7282 100644
+index fa734a66be..e62ad6ac5a 100644
 --- a/include/configs/sifive-unmatched.h
 +++ b/include/configs/sifive-unmatched.h
-@@ -63,6 +63,8 @@
+@@ -55,6 +55,8 @@
  	"name=system,size=-,bootable,type=${type_guid_gpt_system};"
  
  #define CONFIG_EXTRA_ENV_SETTINGS \
 +	"fdt_high=0xffffffffffffffff\0" \
 +	"initrd_high=0xffffffffffffffff\0" \
  	"kernel_addr_r=0x84000000\0" \
- 	"fdt_addr_r=0x88000000\0" \
- 	"scriptaddr=0x88100000\0" \
+ 	"kernel_comp_addr_r=0x88000000\0" \
+ 	"kernel_comp_size=0x4000000\0" \
 -- 
 2.27.0
 


### PR DESCRIPTION
This PR fix the incorrect offset of the u-boot patches. 0005 and 0007 patches are affected.