### PR TITLE
Modify the dependency download script

### DIFF
--- a/build-u-boot.sh
+++ b/build-u-boot.sh
@@ -1,6 +1,6 @@
 CWD=$PWD
 cd $PWD/repos/u-boot/
-pacman -S python3 flex bison swig python-setuptools
+pacman -S --needed --noconfirm python3 flex bison swig python-setuptools base-devel
 git clean -fdx
 git reset --hard origin/master
 git apply $CWD/patches/u-boot/riscv-Fix-build-against-binutils-2.38.diff


### PR DESCRIPTION
We will need base-devel to provide `make` and `gcc` utilities when we
were building the u-boot in a fresh environment. `--needed` can help
ignoring those up-to-date pacakges, and --noconfirm can bypass the
confirmation step.

Signed-off-by: Avimitin <avimitin@gmail.com>